### PR TITLE
multibranch + run

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -1,8 +1,9 @@
 [pullhook]
-#debug=true
-#listen_host=1.2.3.4
-#listen_port=8080
+#debug=false
+#listen_host=0.0.0.0
+#listen_port=7878
 [GithubRepoName1]
 basedir=/path/to/app1
+run=service uwsgi reload app1
 [GithubRepoName2]
 basedir=/path/to/app2

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -1,9 +1,17 @@
 [pullhook]
+# General settings
 #debug=false
 #listen_host=0.0.0.0
 #listen_port=7878
-[GithubRepoName1]
+
+[RepoName1:branch]
+# ^^^^^^^^^^^^^^  This is composed of repo name and (optionally) branch name, separated by a colon
+# basedir:  [required] the full path to where the repo is cloned
 basedir=/path/to/app1
+# run:      [optional] command to run after *EACH* pull
 run=service uwsgi reload app1
-[GithubRepoName2]
+
+[RepoName2]
+# ^^^^^^^  If no branch is specified, it will catch all branches pushes for that repo
 basedir=/path/to/app2
+#run=service uwsgi reload app2

--- a/pullhook.py
+++ b/pullhook.py
@@ -105,10 +105,10 @@ def handle_payload():
         pushed_w_branch = '%s:%s' % (pushed_repo, pushed_branch)
         logger.debug("Received push event from repo %s in branch %s" % (pushed_repo, pushed_branch))
 
-        if pushed_repo in REPOS_CONFIG:
-            configured_repo = REPOS_CONFIG[pushed_repo]
-        elif pushed_w_branch in REPOS_CONFIG:
+        if pushed_w_branch in REPOS_CONFIG:
             configured_repo = REPOS_CONFIG[pushed_w_branch]
+        elif pushed_repo in REPOS_CONFIG:
+            configured_repo = REPOS_CONFIG[pushed_repo]
         else:
             logger.warning('Repo "%s" is not configured on our end. Skipping.' % pushed_repo)
             bottle.abort(404, 'Not configured: %s' % pushed_repo)

--- a/pullhook.py
+++ b/pullhook.py
@@ -5,11 +5,10 @@
         Feel free to bind the server to any ip and port you desire
         just make sure it's accessible by GitHub
 """
-from ConfigParser import SafeConfigParser
-import logging
-
 __author__ = 'talpah@gmail.com'
 
+from ConfigParser import SafeConfigParser
+import logging
 import bottle
 from tendo import singleton
 import git
@@ -72,6 +71,16 @@ def init():
         logger.debug('Found %d repos in config.' % len(REPOS_CONFIG))
 
 
+def run_command(command):
+    if isinstance(command, str):
+        command = command.split(' ')
+    from subprocess import check_output
+
+    logger.debug('Running %s' % ' '.join(command))
+    out = check_output(command)
+    logger.debug('Output: %s' % out)
+
+
 @bottle.route('/', method=['POST'])
 def handle_payload():
     """
@@ -101,6 +110,11 @@ def handle_payload():
         if pushed_branch == branch:
             logger.debug("Pulling new commits.")
             g.pull()
+            if 'run' in configured_repo:
+                try:
+                    run_command(configured_repo['run'])
+                except Exception:
+                    pass
         else:
             logger.debug(
                 'Branches are not corresponding: "%s" (local) and "%s" (remote). Skipping.' % (branch, pushed_branch))

--- a/pullhook.py
+++ b/pullhook.py
@@ -58,7 +58,6 @@ def init():
     else:
         parser = SafeConfigParser()
         parser.read(config_file)
-        print parser.sections()
         MAIN_CONFIG = dict(DEFAULT_CONFIG.items() + dict(parser.items('pullhook')).items())
         if MAIN_CONFIG['debug'].lower() in ['true', 'yes', '1', 'on']:
             logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
It is now possible to use multiple branches for the same repo in config.

```ini
[pullhook:master]
basedir=/apps/pulhook
[pullhook:develop]
basedir=/apps/pulhook-testing
```

Added "run" feature for each section:

```ini
[pullhook:master]
basedir=/apps/pulhook
run=pkill -f /apps/pulhook/pullhook.py
```